### PR TITLE
add new way to load json data

### DIFF
--- a/notebooks/scripts/conf.py
+++ b/notebooks/scripts/conf.py
@@ -1,0 +1,1 @@
+PLAYLISTDIR="some/path"

--- a/notebooks/scripts/load_data2.py
+++ b/notebooks/scripts/load_data2.py
@@ -1,0 +1,15 @@
+import ijson
+import os
+
+from pathlib import Path
+from conf import PLAYLISTDIR
+
+def scan_playlists():
+    current_path = Path.cwd()
+    json_files = os.listdir(current_path / PLAYLISTDIR)
+    uris = []
+    for file in json_files:
+        with open(current_path / PLAYLISTDIR / file, 'rb') as f:
+            uris.append( ijson.items(f, 'playlists.item.tracks.item.track_uri') )
+
+    return uris


### PR DESCRIPTION
Problem with the current way to load json data is that it [loads the data fully into memory](https://github.com/enjuichang/PracticalDataScience-ENCA/blob/4e01e12ad77a8238e160682ca2e4eefd72911848/notebooks/scripts/load_data.py#L12) and then most of that scanned json is thrown away and only track URIs are used for future processing.
I propose to streamline the process of loading json data. The [actual dataset](https://www.aicrowd.com/challenges/spotify-million-playlist-dataset-challenge) consists of 1000 files with json encoded data, with every file containing 1000 playlists. One such file on average takes around 31 MB on disk. Although it may not seem so big, but when processing is performed the usual way by reading the full file into memory, the memory can peak up to 6 times the original file's size (you can check it by any memory profiler, as it was done in [here](https://pythonspeed.com/articles/json-memory-streaming/)).

We need a way to scan these json files in chunks, and [iJson](https://github.com/ICRAR/ijson) is the tool that can help us to do that. The documentation for ijson says that [prefix](https://github.com/ICRAR/ijson#prefix) can be used to select which elements should be built and returned by ijson.

I wrote a [script](https://github.com/oraizen/PracticalDataScience-ENCA/blob/2aa144364bc3b6b47de428086b998b8f743832ba/notebooks/scripts/load_data2.py) that utilizes the ijson library to load the neccessary part from the dataset that we are actually going to use, and return it as the generator.